### PR TITLE
Improve error message when there's no template

### DIFF
--- a/lib/busker.rb
+++ b/lib/busker.rb
@@ -34,7 +34,7 @@ module Busker
 
     def render(name)
       @_[:templates] ||= (Hash[DATA.read.split(/^@@\s*(.*\S)\s*$/)[1..-1].map(&:strip).each_slice(2).to_a] rescue {})
-      ERB.new(@_[:templates][name.to_s] || File.read(name)).result(binding)
+      ERB.new(@_[:templates][name.to_s] || File.read(name.to_s)).result(binding)
     end
 
     def start


### PR DESCRIPTION
If there's an attempt to render non existing template, this is the message a
user gets:

```
no implicit conversion of Symbol into String
```

With this change the update, the error message is a bit more clear:

```
No such file or directory @ rb_sysopen - <template file>
```

Here's a link to [example busker app](https://gist.github.com/bruno-/33958941ba98b02640d6).

Btw great job working on this mini-library. A lot can be learned from it! :+1:
