### PR TITLE
"Simple routes" - routes without a block

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,24 @@ Busker::Busker.new do
     "requested item with id: #{params[:id]}"
   end
 
+  # route without a block renders a template of the same name
+  route '/simple_route'
+
   # list all defined routes
   route '/routes' do |params, request, response|
     response.content_type = 'text/plain'
     @_[:routes].keys.map{|e| e.join("\n")}.join("\n\n")
   end
-  
+
 end.start # notice the call to start
 
 # inline templates like in Sinatra
 __END__
 @@ template
 <h1><%= @title %></h1>
+
+@@ /simple_route
+<h1>Invoked by the simple route</h1>
 ```
 
 ## Questions

--- a/lib/busker.rb
+++ b/lib/busker.rb
@@ -29,7 +29,7 @@ module Busker
     def route(path, methods = ['GET'], opts={}, &block)
       methods = (methods.is_a?(Array) ? methods : [methods]).map{|e| e.to_s.tr('-', '_').upcase}
       matcher = Regexp.new("\\A#{path.gsub(/(:\w+)/){|m| "(?<#{$1[1..-1]}>\\w+)"}}\\Z")
-      @_[:routes][[methods, path, matcher]] = {:opts => opts, :block => block}
+      @_[:routes][[methods, path, matcher]] = {:opts => opts, :block => (block || proc { render path }) }
     end
 
     def render(name)


### PR DESCRIPTION
When a block isn't passed to the route invocation, render a template with the
same name as the route.

I hope you like the idea?

I was unsure about putting this on a separate line within the `route` method,
like this:

```
block ||= proc { render path }
```

That would increase readability, but would add another LOC to the source.
I still opted for the current solution.
