### PR TITLE
Enable route paths as symbol and optional leading '/'

### DIFF
--- a/lib/busker.rb
+++ b/lib/busker.rb
@@ -27,6 +27,7 @@ module Busker
     end
 
     def route(path, methods = ['GET'], opts={}, &block)
+      path = path[0] == '/' ? path.to_s : "/#{path}"
       methods = (methods.is_a?(Array) ? methods : [methods]).map{|e| e.to_s.tr('-', '_').upcase}
       matcher = Regexp.new("\\A#{path.gsub(/(:\w+)/){|m| "(?<#{$1[1..-1]}>\\w+)"}}\\Z")
       @_[:routes][[methods, path, matcher]] = {:opts => opts, :block => block}


### PR DESCRIPTION
So far, all routes must be strings and the first character has to be slash -
'/'.

This commit enables the following:
- routes can be symbols too
- when path is string, leading slash character is optional

@pachacamac, if you like this change, what are your suggestions about updating
the README? I didn't want to add new routes just to show symbols can be used
for paths.. maybe we should change just one of the simpler routes (e.g.
'/info') to symbol, just to show it's possible.
Feedback appreciated!
