### PR TITLE
allow server to disconnect safely

### DIFF
--- a/lib/busker.rb
+++ b/lib/busker.rb
@@ -38,6 +38,7 @@ module Busker
     end
 
     def start
+      trap('INT') { @_[:server].stop }
       @_[:server].start ensure @_[:server].shutdown
     end
   end


### PR DESCRIPTION
the trap function allows the WEBrick server to disconnect safely with CTRL+C
