### PR TITLE
Add POST as a default verb

### DIFF
--- a/lib/busker.rb
+++ b/lib/busker.rb
@@ -28,7 +28,7 @@ module Busker
       end
     end
 
-    def route(path, methods = ['GET'], opts={}, &block)
+    def route(path, methods = ['GET', 'POST'], opts={}, &block)
       path = "/#{path}" unless path[0] == '/'
       methods = Array(methods).map{|e| e.to_s.tr('-', '_').upcase}
       matcher = Regexp.new("\\A#{path.gsub(/(:\w+)/){|m| "(?<#{$1[1..-1]}>\\w+)"}}\\Z")


### PR DESCRIPTION
We currently default the 'route' DSL calls to GET by default, but since Busker is popular with APIs where every GET endpoint also has a POST endpoint for editing those resources, I thought it would be useful to add it as a default verb. We can use `if` statements to catch whether its GET/POST a lot like Python's Flask. :shipit: 